### PR TITLE
Feature/slice pointer integration

### DIFF
--- a/pbl.peb
+++ b/pbl.peb
@@ -1,13 +1,18 @@
-extern fn system(cmd str) int;
-extern fn strlen(s str) usize;
+extern fn malloc(size usize) *void;
+extern fn free(ptr *void) void;
 
 fn main() int {
-    var greeting = "hi";
-    print strlen(greeting);
+    var arr_1 *int = malloc(10 * sizeof int);
+    var slice []int = arr_1[:10];
 
-    // show folder contents
-    system("ls -l");
+    loop 0..10 {
+        slice[iter] = iter;
+    }
 
+    loop 0..10 {
+        print slice[iter];
+    }
 
+    free(arr_1);
     return 0;
 }

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -960,15 +960,27 @@ void emit_expr(Codegen *cg, AstNode *expr) {
   case AST_EXPR_SLICE: {
     emit_string(cg, "(");
     emit_type_name(cg, expr->resolved_type);
-    emit_string(cg, "){ &");
-    emit_expr(cg, expr->data.slice_expr.array);
-    emit_string(cg, ".data[");
-    if (expr->data.slice_expr.start) {
-      emit_expr(cg, expr->data.slice_expr.start);
+    emit_string(cg, "){ ");
+    if (expr->data.slice_expr.array->resolved_type->kind == TYPE_POINTER) {
+      emit_expr(cg, expr->data.slice_expr.array);
+      emit_string(cg, " + ");
+      if (expr->data.slice_expr.start) {
+        emit_expr(cg, expr->data.slice_expr.start);
+      } else {
+        emit_string(cg, "0");
+      }
     } else {
-      emit_string(cg, "0");
+      emit_string(cg, "&");
+      emit_expr(cg, expr->data.slice_expr.array);
+      emit_string(cg, ".data[");
+      if (expr->data.slice_expr.start) {
+        emit_expr(cg, expr->data.slice_expr.start);
+      } else {
+        emit_string(cg, "0");
+      }
+      emit_string(cg, "]");
     }
-    emit_string(cg, "], ");
+    emit_string(cg, ", ");
     if (expr->data.slice_expr.end) {
       emit_expr(cg, expr->data.slice_expr.end);
       emit_string(cg, " - ");


### PR DESCRIPTION
1. Allow index operation on str type (which compiles to `const char *`). Enforce immutability of str (since it is const char *). This needs to be better encoded in the type system.
2. Allow slicing operation on pointers