### PR TITLE
Add proper cleanup for symbol and type tables

### DIFF
--- a/pbl.peb
+++ b/pbl.peb
@@ -1,18 +1,3 @@
-extern fn malloc(size usize) *void;
-extern fn free(ptr *void) void;
+type NamedSlice = []int;
 
-fn main() int {
-    var arr_1 *int = malloc(10 * sizeof int);
-    var slice []int = arr_1[:10];
-
-    loop 0..10 {
-        slice[iter] = iter;
-    }
-
-    loop 0..10 {
-        print slice[iter];
-    }
-
-    free(arr_1);
-    return 0;
-}
+fn main() int => 0

--- a/src/checker.c
+++ b/src/checker.c
@@ -1,10 +1,10 @@
 #include "checker.h"
 #include "alloc.h"
 #include "ast.h"
+#include "options.h"
 #include "symbol.h"
 #include "type.h"
 #include "uthash.h"
-#include "options.h"
 #include <assert.h>
 #include <stdarg.h>
 #include <stddef.h>
@@ -59,7 +59,8 @@ void checker_warning(Location loc, const char *fmt, ...) {
   fprintf(stderr, "\n");
 }
 
-static AstNode *maybe_insert_cast(AstNode *expr, Type *expr_type, Type *target_type);
+static AstNode *maybe_insert_cast(AstNode *expr, Type *expr_type,
+                                  Type *target_type);
 
 //=============================================================================
 // PASS 2: COLLECT GLOBALS
@@ -889,7 +890,8 @@ Type *resolve_type_expression(AstNode *type_expr) {
   case AST_TYPE_STRUCT: {
     size_t field_count = type_expr->data.type_struct.field_count;
     if (field_count == 0) {
-      checker_warning(type_expr->loc, "Struct was declared without any members");
+      checker_warning(type_expr->loc,
+                      "Struct was declared without any members");
       return type_create_struct(NULL, NULL, field_count);
     }
 
@@ -1007,8 +1009,7 @@ static bool is_lvalue(AstNode *expr) {
 
 // Insert implicit cast if needed, returns the (possibly wrapped) expression
 // Returns NULL if types are incompatible
-AstNode *maybe_insert_cast(AstNode *expr, Type *expr_type,
-                                  Type *target_type) {
+AstNode *maybe_insert_cast(AstNode *expr, Type *expr_type, Type *target_type) {
   if (type_equals(expr_type, target_type)) {
     return expr; // No cast needed
   }
@@ -1918,7 +1919,8 @@ static bool check_statement(AstNode *stmt, Type *expected_return_type) {
   }
 
   case AST_STMT_PRINT: {
-    // FIXME: we can maybe setup a user function that can takeover in freestanding cases
+    // FIXME: we can maybe setup a user function that can takeover in
+    // freestanding cases
     if (compiler_opts.freestanding) {
       checker_error(stmt->loc, "cannot use print in freestanding mode");
     }

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -235,6 +235,11 @@ void emit_program(Codegen *cg) {
 
   // Emit sections
   emit_sections(cg);
+
+  // Free global symbol and type tables
+  HASH_CLEAR(hh, global_scope->symbols);
+  HASH_CLEAR(hh, type_table);
+  HASH_CLEAR(hh, canonical_type_table);
 }
 
 void emit_type_name(Codegen *cg, Type *type) {
@@ -359,7 +364,7 @@ void emit_sections(Codegen *cg) {
     cg->defs = NULL;
   }
 
-  // Clear uthash sets (if uthash.h defines HASH_CLEAR)
+  // Clear uthash sets
   HASH_CLEAR(hh, cg->declared_types);
   HASH_CLEAR(hh, cg->defined_types);
   HASH_CLEAR(hh, cg->declared_vars);

--- a/src/symbol.c
+++ b/src/symbol.c
@@ -121,5 +121,6 @@ void scope_push(Scope *scope) {
 // Pop back to parent scope
 void scope_pop(void) {
   assert(current_scope && current_scope->parent);
+  HASH_CLEAR(hh, current_scope->symbols);
   current_scope = current_scope->parent;
 }


### PR DESCRIPTION
Added HASH_CLEAR calls to free symbol and type tables in codegen and scope management, ensuring proper memory cleanup.