### PR TITLE
Add type dependency sorting to codegen

### DIFF
--- a/pbl.peb
+++ b/pbl.peb
@@ -1,3 +1,15 @@
-type NamedSlice = []int;
+type FooPair = (Foo, Foo);
 
-fn main() int => 0
+type Foo = struct {
+  item Bar;
+  data int;
+  self *Foo;
+};
+
+type Bar = struct {
+  a int;
+};
+
+fn main() int {
+  return 0;
+}

--- a/src/checker.c
+++ b/src/checker.c
@@ -2329,16 +2329,17 @@ bool check_function_bodies(void) {
 }
 
 // Verify that the entry point exists and has the correct signature
-// - If entry_point is "main": must exist with signature (void) -> int OR (int, []str) -> int
+// - If entry_point is "main": must exist with signature (void) -> int OR (int,
+// []str) -> int
 // - If entry_point is NOT "main": must exist with signature () -> void
 // - If --no-main is set: skip verification entirely
 bool verify_entry_point(void) {
   const char *entry_name = compiler_opts.entry_point;
   bool is_main = strcmp(entry_name, "main") == 0;
-  
+
   // Look up the entry point function in global scope
   Symbol *entry_sym = scope_lookup(global_scope, entry_name);
-  
+
   if (!entry_sym) {
     // This is fine
     if (!compiler_opts.has_main) {
@@ -2348,31 +2349,31 @@ bool verify_entry_point(void) {
     fprintf(stderr, "error: entry point '%s' not found\n", entry_name);
     return false;
   }
-  
+
   if (entry_sym->kind != SYMBOL_FUNCTION) {
     fprintf(stderr, "error: entry point '%s' is not a function\n", entry_name);
     return false;
   }
-  
+
   // Get the function's type
   Type *func_type = entry_sym->type;
   if (!func_type || func_type->kind != TYPE_FUNCTION) {
     fprintf(stderr, "error: entry point '%s' has invalid type\n", entry_name);
     return false;
   }
-  
+
   Type *return_type = func_type->data.func.return_type;
   size_t param_count = func_type->data.func.param_count;
   Type **param_types = func_type->data.func.param_types;
-  
+
   if (is_main) {
     // main must return int
     if (return_type->kind != TYPE_INT) {
-      fprintf(stderr, "error: main function must return int, not '%s'\n", 
+      fprintf(stderr, "error: main function must return int, not '%s'\n",
               return_type->canonical_name);
       return false;
     }
-    
+
     // main can have 0 or 2 parameters
     // 2 params: fn main(argc int, argv []str) -> int
     if (param_count == 2) {
@@ -2382,28 +2383,31 @@ bool verify_entry_point(void) {
                 param_types[0]->canonical_name);
         return false;
       }
-      
+
       // TODO: Would be nice if this were just []str instead
-      
+
       // Check second param is *str (argv)
       // Array of char*
       Type *argv_type = param_types[1];
       if (argv_type->kind != TYPE_POINTER) {
-        fprintf(stderr, "error: main's second parameter must be *str, not '%s'\n",
+        fprintf(stderr,
+                "error: main's second parameter must be *str, not '%s'\n",
                 argv_type->canonical_name);
         return false;
       }
-      
+
       Type *inner_type = argv_type->data.ptr.base;
       if (inner_type->kind != TYPE_STRING) {
-        fprintf(stderr, "error: main's second parameter must be *str (got %s)\n",
+        fprintf(stderr,
+                "error: main's second parameter must be *str (got %s)\n",
                 argv_type->canonical_name);
         return false;
       }
-      
+
       return true;
     } else if (param_count != 0) {
-      fprintf(stderr, "error: main function must have 0 or 2 parameters, has %zu\n",
+      fprintf(stderr,
+              "error: main function must have 0 or 2 parameters, has %zu\n",
               param_count);
       return false;
     }
@@ -2414,9 +2418,10 @@ bool verify_entry_point(void) {
               entry_name, return_type->canonical_name);
       return false;
     }
-    
+
     if (param_count != 0) {
-      fprintf(stderr, "error: entry point '%s' must take no parameters, has %zu\n",
+      fprintf(stderr,
+              "error: entry point '%s' must take no parameters, has %zu\n",
               entry_name, param_count);
       return false;
     }
@@ -2424,7 +2429,9 @@ bool verify_entry_point(void) {
 
   // Check for no-main (libraries will do this)
   if (!compiler_opts.has_main) {
-    fprintf(stderr, "error: cannot have entry point '%s' when compiling for a library or without an entry point\n",
+    fprintf(stderr,
+            "error: cannot have entry point '%s' when compiling for a library "
+            "or without an entry point\n",
             entry_name);
     return false;
   }

--- a/src/codegen.c
+++ b/src/codegen.c
@@ -6,6 +6,7 @@
 #include "type.h"
 #include <stddef.h>
 #include <stdio.h>
+#include <string.h>
 
 static void append_to_section(Codegen *cg, const char *str, size_t str_len) {
   char **buf = NULL;
@@ -136,17 +137,107 @@ void emit_indent(Codegen *cg) { cg->indent_level++; }
 
 void emit_dedent(Codegen *cg) { cg->indent_level--; }
 
+// Structure to track type dependencies
+typedef struct TypeDep {
+  char *name;
+  size_t dep_count; // Number of OTHER types this depends on
+} TypeDep;
+
+// Count dependencies for a type (excluding self-references)
+size_t count_type_dependencies(Type *t, const char *self_name) {
+  if (!t)
+    return 0;
+
+  if (strcmp(t->canonical_name, self_name))
+    return 0;
+
+  size_t count = 0;
+
+  switch (t->kind) {
+  case TYPE_STRUCT:
+    for (size_t i = 0; i < t->data.struct_data.field_count; i++) {
+      count += count_type_dependencies(t->data.struct_data.field_types[i],
+                                       self_name);
+    }
+    break;
+
+  case TYPE_TUPLE:
+    for (size_t i = 0; i < t->data.tuple.element_count; i++) {
+      count +=
+          count_type_dependencies(t->data.tuple.element_types[i], self_name);
+    }
+    break;
+
+  case TYPE_POINTER:
+    count += count_type_dependencies(t->data.ptr.base, self_name);
+    break;
+
+  case TYPE_ARRAY:
+    count += count_type_dependencies(t->data.array.element, self_name);
+    break;
+
+  default:
+    break;
+  }
+
+  return count;
+}
+
+// Comparison function for qsort
+int compare_type_deps(const void *a, const void *b) {
+  const TypeDep *dep_a = (const TypeDep *)a;
+  const TypeDep *dep_b = (const TypeDep *)b;
+
+  // Sort by dependency count (ascending)
+  if (dep_a->dep_count != dep_b->dep_count) {
+    return dep_a->dep_count - dep_b->dep_count;
+  }
+
+  // Stable sort by name if counts are equal
+  return strcmp(dep_a->name, dep_b->name);
+}
+
 void emit_program(Codegen *cg) {
-  // Emit forwards and defs for types
-  cg->current_section = "forward_types"; // For typedefs
+  // Collect all types and their dependency counts
+  size_t type_count = 0;
   Symbol *sym, *tmp;
+
+  // First pass: count types
   HASH_ITER(hh, global_scope->symbols, sym, tmp) {
     if (sym->kind == SYMBOL_TYPE && sym->type->kind != TYPE_OPAQUE) {
-      Type *t = type_lookup(sym->name);
-      if (t)
-        emit_type_if_needed(cg, t); // Emits typedef and def if struct/tuple
+      type_count++;
     }
   }
+
+  // Build array of type dependencies
+  TypeDep *type_deps = malloc(type_count * sizeof(TypeDep));
+  size_t idx = 0;
+
+  HASH_ITER(hh, global_scope->symbols, sym, tmp) {
+    if (sym->kind == SYMBOL_TYPE && sym->type->kind != TYPE_OPAQUE) {
+      type_deps[idx].name = sym->name;
+      type_deps[idx].dep_count = count_type_dependencies(sym->type, sym->name);
+      idx++;
+    }
+  }
+
+  // Sort by dependency count
+  qsort(type_deps, type_count, sizeof(TypeDep), compare_type_deps);
+
+  // Emit forwards and defs for types
+  cg->current_section = "forward_types"; // For typedefs
+  for (size_t i = 0; i < type_count; i++) {
+    Symbol *type_sym = NULL;
+    HASH_FIND_STR(global_scope->symbols, type_deps[i].name, type_sym);
+    if (type_sym) {
+      Type *t = type_lookup(type_sym->name);
+      if (t) {
+        emit_type_if_needed(cg, t);
+      }
+    }
+  }
+
+  free(type_deps);
 
   // Emit forwards/defs for vars/constants
   cg->current_section = "forward_vars_funcs";


### PR DESCRIPTION
Introduces logic in codegen.c to sort type definitions by dependency count before emitting them, ensuring correct order for forward declarations. Updates pbl.peb with new struct and tuple types, and refines entry point verification in checker.c for improved error messaging and formatting.